### PR TITLE
[Style] 반응형 구현

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,9 +1,16 @@
 .App {
-  max-width: 960px;
+  max-width: 100%;
   margin: 0 auto;
-  padding: 40px;
+  padding: 16px;
   background: white;
   border-radius: 12px;
   display: flex;
   flex-direction: column;
+}
+
+@media (min-width: 768px) {
+  .App {
+    max-width: 840px;
+    padding: 24px;
+  }
 }

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -1,20 +1,24 @@
-.header {
-  display: flex;
-  justify-content: start;
-  align-items: center;
-}
-
 .header-title {
   display: flex;
-  gap: 15px;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
 }
 
 .header-title img {
   width: 40px;
   height: 40px;
 }
+
 .header-title h1 {
   background: linear-gradient(135deg, #00aeef, #9b5eff);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+  font-size: 40px;
+}
+
+@media (min-width: 768px) {
+  .header-title {
+    gap: 16px;
+  }
 }

--- a/src/components/RecordForm/RecordForm.css
+++ b/src/components/RecordForm/RecordForm.css
@@ -1,9 +1,9 @@
 .record-form {
-  display: flex;
-  gap: 15px;
-  align-items: end;
-  margin: 20px 0;
-  padding: 20px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+  margin: 16px 0;
+  padding: 16px;
   width: 100%;
   border-radius: 8px;
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
@@ -12,7 +12,7 @@
 .record-label {
   display: flex;
   flex-direction: column;
-  gap: 5px;
+  gap: 4px;
 }
 
 .record-input {
@@ -20,6 +20,7 @@
   padding: 8px 10px;
   border: 1px solid #ddd;
   border-radius: 5px;
+  width: 100%;
 }
 
 .btn {
@@ -38,5 +39,21 @@
 .btn-submit {
   background: linear-gradient(135deg, #00aeef, #9b5eff);
   color: white;
-  padding: 8px 15px;
+  padding: 10px 14px;
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .record-form {
+    grid-template-columns: 120px 1fr 1fr 1fr auto;
+    align-items: end;
+    gap: 14px;
+    margin: 18px 0;
+    padding: 18px;
+  }
+
+  .btn-submit {
+    width: auto;
+    padding: 8px 15px;
+  }
 }

--- a/src/components/RecordForm/RecordForm.jsx
+++ b/src/components/RecordForm/RecordForm.jsx
@@ -116,6 +116,7 @@ const RecordForm = () => {
           <input
             type="number"
             name="restTime"
+            min={0}
             value={formData.restTime}
             onChange={handleChange}
             className="record-input"

--- a/src/components/RecordItem/RecordItem.css
+++ b/src/components/RecordItem/RecordItem.css
@@ -1,32 +1,50 @@
 .record-item {
   display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  align-items: center;
-  gap: 8px;
-  padding: 12px 16px;
-  border-bottom: 1px solid #f1f1f1;
-  background: #fff;
-}
-.record-item:hover {
-  background: #f9fbff;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  padding: 14px;
+  margin-bottom: 12px;
+  border: 1px solid #eee;
+  border-radius: 10px;
 }
 
 .record-col {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 12px;
+  border: 1px solid #f2f2f2;
+  border-radius: 5px;
+  background: #fafafa;
   font-size: 14px;
   color: #333;
 }
 .record-col.date {
   font-weight: 600;
 }
+.record-col.run::before {
+  content: "러닝";
+  margin-right: 10px;
+}
+.record-col.walk::before {
+  content: "걷기";
+  margin-right: 10px;
+}
+.record-col.rest::before {
+  content: "휴식";
+  margin-right: 10px;
+}
+.record-col.total::before {
+  content: "총 합";
+  margin-right: 10px;
+}
 
 .record-btns {
-  opacity: 0;
   display: flex;
+  gap: 8px;
   justify-content: center;
-  gap: 6px;
-}
-.record-item:hover .record-btns {
   opacity: 1;
+  padding-top: 4px;
 }
 .record-btns .btn {
   padding: 6px 12px;
@@ -36,31 +54,87 @@
 .btn-edit {
   background: linear-gradient(135deg, #e8f9f1, #d9f5e6);
   color: #2e7d32;
+  flex-grow: 1;
 }
 .btn-edit:hover {
   background: #00c853;
   color: #fff;
 }
-
 .btn-delete {
   background: linear-gradient(135deg, #fff1f1, #ffe7e7);
   color: #e53935;
+  flex-grow: 1;
 }
 .btn-delete:hover {
   background: #ff6b6b;
   color: #fff;
 }
-
 .btn-save {
   background: #3f3f3f8c;
-  color: white;
+  color: #fff;
+  flex-grow: 1;
+}
+.btn-cancel {
+  flex-grow: 1;
 }
 
-.editing .record-btns {
-  opacity: 1;
-}
 .editing input {
   width: 60px;
   height: 30px;
   margin-right: 3px;
+}
+
+@media (min-width: 768px) {
+  .record-list__header {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    border-bottom: 1px solid #eee;
+    background: #fafafa;
+    font-size: 12px;
+    font-weight: 600;
+    color: #666;
+  }
+
+  .record-item {
+    grid-template-columns: repeat(6, 1fr);
+    grid-template-areas: "date run walk rest total buttons";
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    border: 0;
+    border-top: 1px solid #f1f1f1;
+    background: #fff;
+    border-radius: 0;
+    margin: 0;
+  }
+  .record-item:hover {
+    background: #f9fbff;
+  }
+
+  .record-col {
+    border: 0;
+    background: transparent;
+    padding: 0;
+  }
+
+  .record-col.date::before,
+  .record-col.run::before,
+  .record-col.walk::before,
+  .record-col.rest::before,
+  .record-col.total::before {
+    content: none;
+  }
+
+  .record-btns {
+    gap: 6px;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    padding-top: 0;
+  }
+  .record-item:hover .record-btns {
+    opacity: 1;
+  }
 }

--- a/src/components/RecordList/RecordList.css
+++ b/src/components/RecordList/RecordList.css
@@ -28,3 +28,10 @@
   display: flex;
   flex-direction: column;
 }
+
+.record-list__empty {
+  text-align: center;
+  color: #777;
+  margin: 40px 0;
+  font-size: 18px;
+}

--- a/src/components/RecordList/RecordList.css
+++ b/src/components/RecordList/RecordList.css
@@ -1,37 +1,79 @@
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.record-tip {
+  display: none;
+}
+
 .record-list {
   width: 100%;
-  margin-top: 20px;
+  margin-top: 16px;
   border-radius: 8px;
-  overflow: hidden;
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
-  background: #fff;
+  background: transparent;
 }
 
 .record-list__header {
-  display: grid;
-  grid-template-columns: repeat(6, 1fr);
-  align-items: center;
-  gap: 8px;
-  padding: 12px 16px;
-  background: linear-gradient(135deg, #f7fbff, #f6f0ff);
-  border-bottom: 2px solid #eee;
-}
-
-.record-list__header .record-col {
-  font-weight: 700;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-image: linear-gradient(135deg, #00aeef, #9b5eff);
-}
-
-.record-list__body {
-  display: flex;
-  flex-direction: column;
+  display: none;
 }
 
 .record-list__empty {
   text-align: center;
   color: #777;
-  margin: 40px 0;
-  font-size: 18px;
+  margin: 32px 0;
+  font-size: 16px;
+}
+
+@media (min-width: 768px) {
+  .record-list {
+    width: 100%;
+    margin-top: 20px;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    background: #fff;
+  }
+
+  .record-list__header {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    background: linear-gradient(135deg, #f7fbff, #f6f0ff);
+    border-bottom: 2px solid #eee;
+  }
+
+  .record-list__header .record-col {
+    font-weight: 700;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-image: linear-gradient(135deg, #00aeef, #9b5eff);
+  }
+
+  .record-list__body {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .record-tip {
+    display: block;
+    margin: 8px 0 14px;
+    padding: 6px 10px;
+    background: #f8faff;
+    border-left: 3px solid #0a6cff;
+    color: #2a4c9a;
+    font-size: 13px;
+    line-height: 1.5;
+    border-radius: 5px;
+  }
+
+  .record-tip__label {
+    font-weight: 700;
+    color: #0a6cff;
+  }
 }

--- a/src/components/RecordList/RecordList.jsx
+++ b/src/components/RecordList/RecordList.jsx
@@ -27,6 +27,10 @@ const RecordList = ({ records, onDelete, onSave }) => {
   return (
     <>
       <div className="toolbar">
+        <p className="record-tip">
+          <span className="record-tip__label">TIP.</span> 기록 항목에 마우스를
+          올리면 <b>수정</b>, <b>삭제</b> 버튼이 표시됩니다.
+        </p>
         <SortSelect value={sortOption} onChange={setSortOption} />
       </div>
 

--- a/src/components/RecordList/SortSelect.css
+++ b/src/components/RecordList/SortSelect.css
@@ -1,13 +1,5 @@
-.toolbar {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  width: 100%;
-  margin-bottom: 10px;
-}
-
 .sort-select {
-  min-width: 100px;
+  width: 100%;
   font-size: 13px;
 }
 
@@ -53,4 +45,10 @@
 
 .rs__option--is-selected {
   background: #00aeef;
+}
+
+@media (min-width: 768px) {
+  .sort-select {
+    width: 200px;
+  }
 }


### PR DESCRIPTION
### 👀 구현 화면
<img width="300" height="500" alt="스크린샷 2025-10-22 212756" src="https://github.com/user-attachments/assets/1808a3f8-7a56-400c-8d5c-d15b291d5e37" />
<img width="1411" height="714" alt="스크린샷 2025-10-22 212738" src="https://github.com/user-attachments/assets/5a8c0f15-7a4a-4563-9856-f3b4f9bf2bea" />

---

### ✅ 변경사항
#### 반응형 스타일 리팩토링 (모바일 퍼스트 구조로 전환)  
- 기존 데스크탑 기준으로 작성된 스타일을 **모바일 기준으로 재정의**하고,  
  768px 이상 화면에서 추가 스타일을 적용하도록 리팩토링함.  

- **App**
  - max-width 지정 및 중앙 정렬 유지
- **Header**
  - 정렬 옵션 레이아웃 조정
- **RecordForm**
  - 모바일에서 인풋 세로 정렬 및 버튼 크기 조정
  - 데스크탑에서는 가로 배치 유지
- **RecordList**
  - 리스트 간격 및 여백 축소
  - 모바일에서 스크롤 시 패딩 추가
- **RecordItem**
  - 모바일(<=767px): 2열 카드형(grid) 구조로 전환
  - PC(>=768px): 테이블 형태 유지

- **SortSelect**
  - 모바일에서 react-select 드롭다운 너비 확장
  - 데스크탑에서는 기존 너비 유지
